### PR TITLE
deps: bump androidx.core:core-ktx from 1.13.1 to 1.15.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.5.2"
 kotlin = "1.9.0"
-coreKtx = "1.13.1"
+coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"


### PR DESCRIPTION
Bumps androidx.core:core-ktx from 1.13.1 to 1.15.0.

---
updated-dependencies:
- dependency-name: androidx.core:core-ktx dependency-type: direct:production update-type: version-update:semver-minor ...