### PR TITLE
deps: bump androidx.lifecycle:lifecycle-runtime-ktx from 2.8.4 to 2.8.7

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.4"
+lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.1"
 composeBom = "2024.08.00"
 


### PR DESCRIPTION
Bumps androidx.lifecycle:lifecycle-runtime-ktx from 2.8.4 to 2.8.7.

---
updated-dependencies:
- dependency-name: androidx.lifecycle:lifecycle-runtime-ktx dependency-type: direct:production update-type: version-update:semver-patch ...