### PR TITLE
deps: bump androidx.compose:compose-bom from 2024.08.00 to 2024.11.00

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.4"
 activityCompose = "1.9.1"
-composeBom = "2024.08.00"
+composeBom = "2024.11.00"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
Bumps androidx.compose:compose-bom from 2024.08.00 to 2024.11.00.

---
updated-dependencies:
- dependency-name: androidx.compose:compose-bom dependency-type: direct:production ...